### PR TITLE
add loadIsActivated call check

### DIFF
--- a/client/src/routes/widgetModule/WidgetModule.tsx
+++ b/client/src/routes/widgetModule/WidgetModule.tsx
@@ -33,6 +33,7 @@ interface Props {
 
 export const WidgetModule: React.FC<Props> = observer(({ domainName }) => {
   const { domainStore, walletStore } = useStores()
+  const [checkIsActivated, setCheckIsActivated] = useState(false)
   const [processStatus, setProcessStatus] = useState<ProcessStatusItem>({
     type: ProcessStatusTypes.IDLE,
     render: '',
@@ -43,9 +44,13 @@ export const WidgetModule: React.FC<Props> = observer(({ domainName }) => {
   }, [domainName])
 
   useEffect(() => {
+    const checkActivated = async () => {
+      await widgetListStore.loadIsActivated(domainName)
+      setCheckIsActivated(true)
+    }
     widgetListStore.loadWidgetList(domainName)
     widgetListStore.loadDomainTx(domainName)
-    widgetListStore.loadIsActivated(domainName)
+    checkActivated()
   }, [domainName])
 
   const [isLoading, setLoading] = useState(false)
@@ -200,7 +205,7 @@ export const WidgetModule: React.FC<Props> = observer(({ domainName }) => {
             onKeyDown={enterHandler}
           />
 
-          {!widgetListStore.isActivated && (
+          {checkIsActivated && !widgetListStore.isActivated && (
             <Box pad={{ top: '0.5em' }}>
               <SmallText>
                 Your first transaction when trying to add a post is an


### PR DESCRIPTION
loadIsActivated is sometimes called after component rendering

{!widgetListStore.isActivated && (
            <Box pad={{ top: '0.5em' }}>
              <SmallText>
                Your first transaction when trying to add a post is an
                activation transaction which is followed by a post addition
                transaction
              </SmallText>
            </Box>
          )}

Issue: 
https://github.com/harmony-one/1-country.frontend/issues/121